### PR TITLE
Make tempest fixed network name optional

### DIFF
--- a/tasks/tempest_verifiers.yml
+++ b/tasks/tempest_verifiers.yml
@@ -61,7 +61,9 @@
       tempest_cirros_image_uuid: "{{ image_id.stdout }}"
       tempest_flavor_uuid: "{{ flavor_id.stdout }}"
       tempest_second_flavor_uuid: "{{ second_flavor_id.stdout }}"
+  - name: Set tempest network name if provided
       tempest_network_name: "{{ item.value.network_name }}"
+    when: item.value.network_name is defined
 
   - name: store tempest configs in a persistent place
     file:

--- a/templates/tempest.j2
+++ b/templates/tempest.j2
@@ -7,7 +7,9 @@ image_ref = {{ tempest_cirros_image_uuid }}
 image_ref_alt = {{ tempest_cirros_image_uuid }}
 flavor_ref = {{ tempest_flavor_uuid }}
 flavor_ref_alt = {{ tempest_second_flavor_uuid }}
+{% if tempest_network_name is defined %}
 fixed_network_name = {{ tempest_network_name }}
+{% endif %}
 
 [object-storage]
 swift_operator_role = {{ rally_tempest_swift_operator_role }}


### PR DESCRIPTION
Allow users to specify if tempest fixed_network_name is defined. 